### PR TITLE
make mcp server instructions configurable

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2368,6 +2368,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_spanned"
+version = "0.6.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf41e0cfaf7226dca15e8197172c295a782857fcb97fad1808a166870dee75a3"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "serde_yaml_ng"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2680,6 +2689,7 @@ dependencies = [
  "serde",
  "serde_json",
  "tokio",
+ "toml",
  "traverze",
 ]
 
@@ -2827,6 +2837,47 @@ dependencies = [
  "pin-project-lite",
  "tokio",
 ]
+
+[[package]]
+name = "toml"
+version = "0.8.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc1beb996b9d83529a9e75c17a1686767d148d70663143c7854d8b4a09ced362"
+dependencies = [
+ "serde",
+ "serde_spanned",
+ "toml_datetime",
+ "toml_edit",
+]
+
+[[package]]
+name = "toml_datetime"
+version = "0.6.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22cddaf88f4fbc13c51aebbf5f8eceb5c7c5a9da2ac40a13519eb5b0a0e8f11c"
+dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "toml_edit"
+version = "0.22.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41fe8c660ae4257887cf66394862d21dbca4a6ddd26f04a3560410406a2f819a"
+dependencies = [
+ "indexmap",
+ "serde",
+ "serde_spanned",
+ "toml_datetime",
+ "toml_write",
+ "winnow",
+]
+
+[[package]]
+name = "toml_write"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d99f8c9a7727884afe522e9bd5edbfc91a3312b36a77b5fb8926e4c31a41801"
 
 [[package]]
 name = "tower"
@@ -3495,6 +3546,15 @@ name = "windows_x86_64_msvc"
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d6bbff5f0aada427a1e5a6da5f1f98158182f26556f345ac9e04d36d0ebed650"
+
+[[package]]
+name = "winnow"
+version = "0.7.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df79d97927682d2fd8adb29682d1140b343be4ac0f08fd68b7765d9c059d3945"
+dependencies = [
+ "memchr",
+]
 
 [[package]]
 name = "wit-bindgen"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,4 +11,5 @@ schemars = "1"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 tokio = { version = "1.47.1", features = ["macros", "rt-multi-thread"] }
+toml = "0.8"
 traverze = { version = "0.2.0", features = ["tokenizer-lindera-ipadic"] }

--- a/src/main.rs
+++ b/src/main.rs
@@ -19,6 +19,30 @@ struct Cli {
     /// Path to the directory containing Markdown files
     #[arg(long)]
     dir: PathBuf,
+    /// Path to a TOML config file for customizing tool descriptions
+    #[arg(long)]
+    config: Option<PathBuf>,
+}
+
+// ---------------------------------------------------------------------------
+// Config
+// ---------------------------------------------------------------------------
+
+#[derive(Deserialize, Default)]
+#[serde(default)]
+struct Config {
+    instructions: Option<String>,
+    search_description: Option<String>,
+    read_file_description: Option<String>,
+}
+
+impl Config {
+    fn load(path: &Path) -> Result<Self> {
+        let content = fs::read_to_string(path)
+            .with_context(|| format!("failed to read config file: {}", path.display()))?;
+        toml::from_str(&content)
+            .with_context(|| format!("failed to parse config file: {}", path.display()))
+    }
 }
 
 // ---------------------------------------------------------------------------
@@ -51,6 +75,7 @@ struct TerrainServer {
     engine: Traverze,
     base_dir: PathBuf,
     tool_router: ToolRouter<Self>,
+    instructions: String,
 }
 
 #[tool_router]
@@ -110,20 +135,39 @@ impl ServerHandler for TerrainServer {
     fn get_info(&self) -> ServerInfo {
         ServerInfo {
             capabilities: ServerCapabilities::builder().enable_tools().build(),
-            instructions: Some(
-                "terrain MCP server – search and read indexed Markdown files".to_string(),
-            ),
+            instructions: Some(self.instructions.clone()),
             ..Default::default()
         }
     }
 }
 
 impl TerrainServer {
-    fn new(engine: Traverze, base_dir: PathBuf) -> Self {
+    fn new(engine: Traverze, base_dir: PathBuf, config: &Config) -> Self {
+        let mut router = Self::tool_router();
+
+        if let Some(desc) = &config.search_description {
+            if let Some(route) = router.map.get_mut("search") {
+                route.attr.description = Some(desc.clone().into());
+            }
+        }
+        if let Some(desc) = &config.read_file_description {
+            if let Some(route) = router.map.get_mut("read_file") {
+                route.attr.description = Some(desc.clone().into());
+            }
+        }
+
+        let instructions = config
+            .instructions
+            .clone()
+            .unwrap_or_else(|| {
+                "terrain MCP server – search and read indexed Markdown files".to_string()
+            });
+
         Self {
             engine,
             base_dir,
-            tool_router: Self::tool_router(),
+            tool_router: router,
+            instructions,
         }
     }
 }
@@ -136,6 +180,10 @@ impl TerrainServer {
 async fn main() -> Result<()> {
     let cli = Cli::parse();
     let target_dir = resolve_dir(&cli.dir)?;
+    let config = match &cli.config {
+        Some(path) => Config::load(path)?,
+        None => Config::default(),
+    };
     let markdown_files = collect_markdown_files(&target_dir)?;
 
     let index_dir = env::temp_dir().join("terrain-index");
@@ -151,7 +199,7 @@ async fn main() -> Result<()> {
         target_dir.display()
     );
 
-    let server = TerrainServer::new(engine, target_dir)
+    let server = TerrainServer::new(engine, target_dir, &config)
         .serve(stdio())
         .await?;
     server.waiting().await?;

--- a/terrain.config.example.toml
+++ b/terrain.config.example.toml
@@ -1,0 +1,15 @@
+# terrain MCP server configuration
+#
+# Customize the descriptions sent to the AI model.
+# All fields are optional — omitted fields use the built-in defaults.
+#
+# Usage: terrain --dir ./docs --config terrain.config.toml
+
+# Server-level instruction provided to the AI model.
+instructions = "terrain MCP server – search and read indexed Markdown files"
+
+# Description for the "search" tool.
+search_description = "Search local Markdown files (knowledge base) using full-text search. This engine is highly optimized for Japanese text using morphological analysis, so you can confidently pass natural Japanese keywords, phrases, or technical terms. Use this as your first action to find relevant context to answer the user's question. It returns a list of matching absolute file paths, relevance scores, and surrounding text snippets."
+
+# Description for the "read_file" tool.
+read_file_description = "Read the full contents of a specific Markdown file. Use this when you find a promising snippet from the 'search' tool and need more detailed context, full sections, or complete code blocks. Provide the exact absolute file path retrieved from the search results."


### PR DESCRIPTION
## Summary

Allow users to override MCP server `instructions` and tool `description` values via an external TOML configuration file, without rebuilding the binary.

### Changes

- **Add `--config <path>` CLI option** — Accepts a path to a TOML config file. When omitted, built-in defaults are used.
- **Add `Config` struct** — Supports three optional fields: `instructions`, `search_description`, and `read_file_description`. Omitted fields fall back to the built-in defaults.
- **Dynamically override tool descriptions in `TerrainServer::new()`** — Mutates `ToolRouter.map` entries directly, keeping the existing macros (`#[tool_router]`, `#[tool_handler]`) intact.
- **Add `terrain.config.example.toml`** — A sample config file with the default values pre-filled for easy customization.

### Motivation

Previously, all descriptions sent to the AI model were hardcoded in the source code. This made it impossible to tailor prompts to specific domains or use cases without modifying and rebuilding the binary. With this change, users can iterate on prompt engineering by simply editing a config file.

## Summary
MCPサーバーの`instructions`および各ツールの`description`を、外部TOML設定ファイルで上書きできるようにした。

## Changes
- **`--config <path>`CLIオプションを追加** — TOML設定ファイルのパスを指定可能に。省略時は従来のデフォルト値で動作
- **`Config`構造体を追加** —`instructions`, `search_description`, `read_file_description`の3項目を設定可能。全フィールドOptionalで、未指定の項目はビルトインのデフォルト値にフォールバック
- **`TerrainServer::new()`でツールのdescriptionを動的に上書き** — rmcpの`ToolRouter.map`を直接書き換える方式を採用し、既存のマクロ(`#[tool_router`], `#[tool_handler]`)はそのまま維持
- **`terrain.config.example.toml`を追加** — デフォルト値を記載したサンプル設定ファイル

## Motivation

ハードコードされたdescriptionでは、ユーザーのドメインやユースケースに合わせた最適化ができなかった。設定ファイルにより、再ビルド不要でプロンプトエンジニアリングの反復が可能になる。