### PR TITLE
add a readme

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,8 +4,8 @@ version = "0.1.0"
 edition = "2024"
 
 [dependencies]
-anyhow = "1.0.98"
-clap = { version = "4", features = ["derive"] }
+anyhow = "1.0"
+clap = { version = "4.5", features = ["derive"] }
 rmcp = { version = "0.17.0", features = ["server", "transport-io"] }
 schemars = "1"
 serde = { version = "1", features = ["derive"] }

--- a/README.md
+++ b/README.md
@@ -1,0 +1,81 @@
+# terrain
+
+`terrain` is a high-performance, local-first full-text search engine for your Markdown knowledge base, optimized for Japanese text.
+
+It runs as a command-line MCP (Model Context Protocol) server, indexing a specified directory of `.md` files and exposing powerful search and retrieval tools.
+
+## Features
+
+- **Blazing-Fast Search:** Powered by the `traverze` search engine.
+- **Optimized for Japanese:** Utilizes `Lindera` with an IPADIC dictionary for accurate morphological analysis and tokenization of Japanese text.
+- **MCP Server:** Exposes a simple, machine-readable tool interface over standard I/O.
+- **Secure:** File access is restricted to the indexed directory to prevent unauthorized access.
+- **Cross-Platform:** Built with Rust, runs on Windows, macOS, and Linux.
+
+## Usage
+
+1.  **Start the server:**
+    Run the program from your terminal, pointing it to the directory containing your Markdown files.
+
+    ```bash
+    terrain --dir /path/to/your/notes
+    ```
+
+2.  **Indexing:**
+    The server will first index all Markdown files in the specified directory. You will see a message indicating how many files have been indexed.
+
+    ```
+    indexed 1234 markdown files from /path/to/your/notes
+    ```
+
+3.  **Interact via MCP:**
+    Once indexed, the server listens on `stdin` for MCP JSON requests and sends responses to `stdout`. You can use this interface with any MCP-compatible client or controller.
+
+## Building
+
+To build the project from the source, you need to have Rust installed.
+
+1.  Clone the repository:
+    ```bash
+    git clone <repository-url>
+    cd terrain
+    ```
+
+2.  Build the project:
+    ```bash
+    cargo build --release
+    ```
+    The executable will be located at `target/release/terrain`.
+
+## MCP Tools
+
+The server provides the following tools:
+
+### `search`
+
+Search indexed Markdown files and return matching file paths, scores, and snippets.
+
+- **Description:** This tool is highly optimized for Japanese text. Use it to find relevant context to answer a user's question. It returns a list of matching absolute file paths, relevance scores, and surrounding text snippets.
+- **Parameters:**
+    - `query` (string, required): The search query. You can specify multiple keywords separated by spaces.
+    - `limit` (integer, optional): The maximum number of search results to return (default: 20).
+- **Example Return Value:**
+    ```json
+    [
+      {
+        "path": "/path/to/your/notes/example.md",
+        "score": 18.72,
+        "snippet": "This is a snippet of text surrounding the matched keyword."
+      }
+    ]
+    ```
+
+### `read_file`
+
+Read the full contents of a specific Markdown file.
+
+- **Description:** Use this when you find a promising snippet from the `search` tool and need more detailed context. Provide the exact absolute file path retrieved from the search results.
+- **Parameters:**
+    - `path` (string, required): The absolute path of the Markdown file to read. You must use the exact path returned by the `search` tool.
+- **Example Return Value:**
+    The full, raw content of the specified Markdown file.


### PR DESCRIPTION
## Summary (EN)

- Add README.md with project overview, usage instructions, build steps, and MCP tools documentation
- Clean up dependency versions in Cargo.toml (remove `rust-version`, adjust `anyhow` / `clap` versions)

## Changes

### README.md (new)
- Project overview (local-first full-text search engine optimized for Japanese)
- Usage: starting the server, indexing, interacting via MCP
- Build instructions (Rust)
- `search` / `read_file` tool parameters and return values

### Cargo.toml
- Remove `rust-version` field
- Adjust `anyhow` to `"1.0"`, `clap` to `"4.5"`

---

## Summary

- README.md を新規追加し、プロジェクト概要・使い方・ビルド手順・MCPツールのドキュメントを整備
- Cargo.toml の依存関係バージョンを整理（`rust-version` 削除、`anyhow` / `clap` のバージョン指定を調整）

## 変更内容の詳細

### README.md（新規）
- プロジェクトの概要（日本語最適化のローカル全文検索エンジン）
- 起動方法・インデックス作成・MCP経由の操作手順
- ビルド手順（Rust）
- `search` / `read_file` ツールのパラメータと戻り値の説明

### Cargo.toml
- `rust-version` フィールドを削除
- `anyhow` を `"1.0"` に、`clap` を `"4.5"` に調整
