### PR TITLE
extract core logic into library crate

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,9 +3,17 @@ name = "terrain"
 version = "0.1.0"
 edition = "2024"
 
+[[bin]]
+name = "terrain"
+required-features = ["cli"]
+
+[features]
+default = ["cli"]
+cli = ["dep:clap"]
+
 [dependencies]
 anyhow = "1.0"
-clap = { version = "4.5", features = ["derive"] }
+clap = { version = "4.5", features = ["derive"], optional = true }
 rmcp = { version = "0.17.0", features = ["server", "transport-io"] }
 schemars = "1"
 serde = { version = "1", features = ["derive"] }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -142,12 +142,9 @@ impl TerrainServer {
             }
         }
 
-        let instructions = config
-            .instructions
-            .clone()
-            .unwrap_or_else(|| {
-                "terrain MCP server – search and read indexed Markdown files".to_string()
-            });
+        let instructions = config.instructions.clone().unwrap_or_else(|| {
+            "terrain MCP server – search and read indexed Markdown files".to_string()
+        });
 
         Self {
             engine,
@@ -207,9 +204,8 @@ pub fn collect_markdown_files(base_dir: &Path) -> Result<Vec<PathBuf>> {
 
 /// Create a `Traverze` engine and index the given Markdown files.
 pub fn build_engine(index_dir: &Path, files: &[PathBuf]) -> Result<(Traverze, usize)> {
-    let engine =
-        Traverze::new_in_dir_for_indexing(index_dir, TokenizerMode::LinderaIpadic, true)
-            .context("traverze index initialization failed")?;
+    let engine = Traverze::new_in_dir_for_indexing(index_dir, TokenizerMode::LinderaIpadic, true)
+        .context("traverze index initialization failed")?;
     let indexed = engine
         .index_files(files)
         .context("failed to index markdown files")?;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,0 +1,217 @@
+use std::fs;
+use std::path::{Path, PathBuf};
+
+use anyhow::{Context, Result, bail};
+use rmcp::handler::server::tool::ToolRouter;
+use rmcp::handler::server::wrapper::Parameters;
+use rmcp::model::{ServerCapabilities, ServerInfo};
+use rmcp::{ServerHandler, tool, tool_handler, tool_router};
+use schemars::JsonSchema;
+use serde::Deserialize;
+use traverze::{SearchOptions, SnippetOptions, TokenizerMode, Traverze};
+
+// ---------------------------------------------------------------------------
+// Config
+// ---------------------------------------------------------------------------
+
+#[derive(Deserialize, Default)]
+#[serde(default)]
+pub struct Config {
+    pub instructions: Option<String>,
+    pub search_description: Option<String>,
+    pub read_file_description: Option<String>,
+}
+
+impl Config {
+    pub fn load(path: &Path) -> Result<Self> {
+        let content = fs::read_to_string(path)
+            .with_context(|| format!("failed to read config file: {}", path.display()))?;
+        toml::from_str(&content)
+            .with_context(|| format!("failed to parse config file: {}", path.display()))
+    }
+}
+
+// ---------------------------------------------------------------------------
+// MCP Tool parameters
+// ---------------------------------------------------------------------------
+
+#[derive(Deserialize, JsonSchema)]
+struct SearchParams {
+    /// The search query string. You can specify multiple keywords separated by spaces.
+    /// Japanese text is fully supported and accurately tokenized using morphological analysis.
+    query: String,
+    /// The maximum number of search results to return (default: 20).
+    /// Keep this reasonable to avoid overflowing your context window.
+    limit: Option<usize>,
+}
+
+#[derive(Deserialize, JsonSchema)]
+struct ReadFileParams {
+    /// The absolute path of the Markdown file to read.
+    /// You must use the exact path returned by the 'search' tool.
+    path: String,
+}
+
+// ---------------------------------------------------------------------------
+// TerrainServer
+// ---------------------------------------------------------------------------
+
+#[derive(Clone)]
+pub struct TerrainServer {
+    engine: Traverze,
+    base_dir: PathBuf,
+    tool_router: ToolRouter<Self>,
+    instructions: String,
+}
+
+#[tool_router]
+impl TerrainServer {
+    /// Search indexed Markdown files and return matching file paths, scores,
+    /// and snippets.
+    #[tool(
+        name = "search",
+        description = "Search local Markdown files (knowledge base) using full-text search. This engine is highly optimized for Japanese text using morphological analysis, so you can confidently pass natural Japanese keywords, phrases, or technical terms. Use this as your first action to find relevant context to answer the user's question. It returns a list of matching absolute file paths, relevance scores, and surrounding text snippets."
+    )]
+    async fn search(&self, Parameters(params): Parameters<SearchParams>) -> Result<String, String> {
+        let options = SearchOptions {
+            limit: params.limit.unwrap_or(20),
+            snippet: Some(SnippetOptions::default()),
+        };
+        let hits = self
+            .engine
+            .search_with_options(&params.query, options)
+            .map_err(|e| format!("search failed: {e}"))?;
+
+        let results: Vec<serde_json::Value> = hits
+            .iter()
+            .map(|h| {
+                serde_json::json!({
+                    "path": h.path,
+                    "score": h.score,
+                    "snippet": h.snippet,
+                })
+            })
+            .collect();
+
+        serde_json::to_string_pretty(&results).map_err(|e| format!("serialization failed: {e}"))
+    }
+
+    /// Read the contents of a file within the indexed directory.
+    #[tool(
+        name = "read_file",
+        description = "Read the full contents of a specific Markdown file. Use this when you find a promising snippet from the 'search' tool and need more detailed context, full sections, or complete code blocks. Provide the exact absolute file path retrieved from the search results."
+    )]
+    async fn read_file(
+        &self,
+        Parameters(params): Parameters<ReadFileParams>,
+    ) -> Result<String, String> {
+        let canonical = fs::canonicalize(&params.path)
+            .map_err(|e| format!("file not found: {}: {e}", params.path))?;
+
+        if !canonical.starts_with(&self.base_dir) {
+            return Err("access denied: path is outside the indexed directory".to_string());
+        }
+
+        fs::read_to_string(&canonical).map_err(|e| format!("failed to read file: {e}"))
+    }
+}
+
+#[tool_handler]
+impl ServerHandler for TerrainServer {
+    fn get_info(&self) -> ServerInfo {
+        ServerInfo {
+            capabilities: ServerCapabilities::builder().enable_tools().build(),
+            instructions: Some(self.instructions.clone()),
+            ..Default::default()
+        }
+    }
+}
+
+impl TerrainServer {
+    pub fn new(engine: Traverze, base_dir: PathBuf, config: &Config) -> Self {
+        let mut router = Self::tool_router();
+
+        if let Some(desc) = &config.search_description {
+            if let Some(route) = router.map.get_mut("search") {
+                route.attr.description = Some(desc.clone().into());
+            }
+        }
+        if let Some(desc) = &config.read_file_description {
+            if let Some(route) = router.map.get_mut("read_file") {
+                route.attr.description = Some(desc.clone().into());
+            }
+        }
+
+        let instructions = config
+            .instructions
+            .clone()
+            .unwrap_or_else(|| {
+                "terrain MCP server – search and read indexed Markdown files".to_string()
+            });
+
+        Self {
+            engine,
+            base_dir,
+            tool_router: router,
+            instructions,
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Utility functions
+// ---------------------------------------------------------------------------
+
+pub fn resolve_dir(dir: &Path) -> Result<PathBuf> {
+    let canonical =
+        fs::canonicalize(dir).with_context(|| format!("directory not found: {}", dir.display()))?;
+
+    if !canonical.is_dir() {
+        bail!("not a directory: {}", canonical.display());
+    }
+
+    Ok(canonical)
+}
+
+pub fn collect_markdown_files(base_dir: &Path) -> Result<Vec<PathBuf>> {
+    let mut stack = vec![base_dir.to_path_buf()];
+    let mut files = Vec::new();
+
+    while let Some(dir) = stack.pop() {
+        for entry in fs::read_dir(&dir)
+            .with_context(|| format!("failed to read directory: {}", dir.display()))?
+        {
+            let entry = entry?;
+            let path = entry.path();
+            let file_type = entry.file_type()?;
+
+            if file_type.is_dir() {
+                stack.push(path);
+                continue;
+            }
+
+            if file_type.is_file()
+                && path
+                    .extension()
+                    .and_then(|ext| ext.to_str())
+                    .map(|ext| ext.eq_ignore_ascii_case("md"))
+                    .unwrap_or(false)
+            {
+                files.push(path);
+            }
+        }
+    }
+
+    Ok(files)
+}
+
+/// Create a `Traverze` engine and index the given Markdown files.
+pub fn build_engine(index_dir: &Path, files: &[PathBuf]) -> Result<(Traverze, usize)> {
+    let engine =
+        Traverze::new_in_dir_for_indexing(index_dir, TokenizerMode::LinderaIpadic, true)
+            .context("traverze index initialization failed")?;
+    let indexed = engine
+        .index_files(files)
+        .context("failed to index markdown files")?;
+    Ok((engine, indexed))
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -29,8 +29,8 @@ async fn main() -> Result<()> {
     let markdown_files = collect_markdown_files(&target_dir)?;
 
     let index_dir = env::temp_dir().join("terrain-index");
-    let (engine, indexed) = build_engine(&index_dir, &markdown_files)
-        .context("failed to build search engine")?;
+    let (engine, indexed) =
+        build_engine(&index_dir, &markdown_files).context("failed to build search engine")?;
 
     eprintln!(
         "indexed {} markdown files from {}",

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,16 +1,10 @@
 use std::env;
-use std::fs;
-use std::path::{Path, PathBuf};
+use std::path::PathBuf;
 
-use anyhow::{Context, Result, bail};
+use anyhow::{Context, Result};
 use clap::Parser;
-use rmcp::handler::server::tool::ToolRouter;
-use rmcp::handler::server::wrapper::Parameters;
-use rmcp::model::{ServerCapabilities, ServerInfo};
-use rmcp::{ServerHandler, ServiceExt, tool, tool_handler, tool_router, transport::stdio};
-use schemars::JsonSchema;
-use serde::Deserialize;
-use traverze::{SearchOptions, SnippetOptions, TokenizerMode, Traverze};
+use rmcp::{ServiceExt, transport::stdio};
+use terrain::{Config, TerrainServer, build_engine, collect_markdown_files, resolve_dir};
 
 /// terrain MCP server – Markdown full-text search
 #[derive(Parser)]
@@ -19,162 +13,10 @@ struct Cli {
     /// Path to the directory containing Markdown files
     #[arg(long)]
     dir: PathBuf,
-    /// Path to a TOML config file for customizing tool descriptions
+    /// Path to a TOML config file for customizing tool description
     #[arg(long)]
     config: Option<PathBuf>,
 }
-
-// ---------------------------------------------------------------------------
-// Config
-// ---------------------------------------------------------------------------
-
-#[derive(Deserialize, Default)]
-#[serde(default)]
-struct Config {
-    instructions: Option<String>,
-    search_description: Option<String>,
-    read_file_description: Option<String>,
-}
-
-impl Config {
-    fn load(path: &Path) -> Result<Self> {
-        let content = fs::read_to_string(path)
-            .with_context(|| format!("failed to read config file: {}", path.display()))?;
-        toml::from_str(&content)
-            .with_context(|| format!("failed to parse config file: {}", path.display()))
-    }
-}
-
-// ---------------------------------------------------------------------------
-// MCP Tool parameters
-// ---------------------------------------------------------------------------
-
-#[derive(Deserialize, JsonSchema)]
-struct SearchParams {
-    /// The search query string. You can specify multiple keywords separated by spaces.
-    /// Japanese text is fully supported and accurately tokenized using morphological analysis.
-    query: String,
-    /// The maximum number of search results to return (default: 20).
-    /// Keep this reasonable to avoid overflowing your context window.
-    limit: Option<usize>,
-}
-
-#[derive(Deserialize, JsonSchema)]
-struct ReadFileParams {
-    /// The absolute path of the Markdown file to read.
-    /// You must use the exact path returned by the 'search' tool.
-    path: String,
-}
-
-// ---------------------------------------------------------------------------
-// TerrainServer
-// ---------------------------------------------------------------------------
-
-#[derive(Clone)]
-struct TerrainServer {
-    engine: Traverze,
-    base_dir: PathBuf,
-    tool_router: ToolRouter<Self>,
-    instructions: String,
-}
-
-#[tool_router]
-impl TerrainServer {
-    /// Search indexed Markdown files and return matching file paths, scores,
-    /// and snippets.
-    #[tool(
-        name = "search",
-        description = "Search local Markdown files (knowledge base) using full-text search. This engine is highly optimized for Japanese text using morphological analysis, so you can confidently pass natural Japanese keywords, phrases, or technical terms. Use this as your first action to find relevant context to answer the user's question. It returns a list of matching absolute file paths, relevance scores, and surrounding text snippets."
-    )]
-    async fn search(&self, Parameters(params): Parameters<SearchParams>) -> Result<String, String> {
-        let options = SearchOptions {
-            limit: params.limit.unwrap_or(20),
-            snippet: Some(SnippetOptions::default()),
-        };
-        let hits = self
-            .engine
-            .search_with_options(&params.query, options)
-            .map_err(|e| format!("search failed: {e}"))?;
-
-        let results: Vec<serde_json::Value> = hits
-            .iter()
-            .map(|h| {
-                serde_json::json!({
-                    "path": h.path,
-                    "score": h.score,
-                    "snippet": h.snippet,
-                })
-            })
-            .collect();
-
-        serde_json::to_string_pretty(&results).map_err(|e| format!("serialization failed: {e}"))
-    }
-
-    /// Read the contents of a file within the indexed directory.
-    #[tool(
-        name = "read_file",
-        description = "Read the full contents of a specific Markdown file. Use this when you find a promising snippet from the 'search' tool and need more detailed context, full sections, or complete code blocks. Provide the exact absolute file path retrieved from the search results."
-    )]
-    async fn read_file(
-        &self,
-        Parameters(params): Parameters<ReadFileParams>,
-    ) -> Result<String, String> {
-        let canonical = fs::canonicalize(&params.path)
-            .map_err(|e| format!("file not found: {}: {e}", params.path))?;
-
-        if !canonical.starts_with(&self.base_dir) {
-            return Err("access denied: path is outside the indexed directory".to_string());
-        }
-
-        fs::read_to_string(&canonical).map_err(|e| format!("failed to read file: {e}"))
-    }
-}
-
-#[tool_handler]
-impl ServerHandler for TerrainServer {
-    fn get_info(&self) -> ServerInfo {
-        ServerInfo {
-            capabilities: ServerCapabilities::builder().enable_tools().build(),
-            instructions: Some(self.instructions.clone()),
-            ..Default::default()
-        }
-    }
-}
-
-impl TerrainServer {
-    fn new(engine: Traverze, base_dir: PathBuf, config: &Config) -> Self {
-        let mut router = Self::tool_router();
-
-        if let Some(desc) = &config.search_description {
-            if let Some(route) = router.map.get_mut("search") {
-                route.attr.description = Some(desc.clone().into());
-            }
-        }
-        if let Some(desc) = &config.read_file_description {
-            if let Some(route) = router.map.get_mut("read_file") {
-                route.attr.description = Some(desc.clone().into());
-            }
-        }
-
-        let instructions = config
-            .instructions
-            .clone()
-            .unwrap_or_else(|| {
-                "terrain MCP server – search and read indexed Markdown files".to_string()
-            });
-
-        Self {
-            engine,
-            base_dir,
-            tool_router: router,
-            instructions,
-        }
-    }
-}
-
-// ---------------------------------------------------------------------------
-// main
-// ---------------------------------------------------------------------------
 
 #[tokio::main]
 async fn main() -> Result<()> {
@@ -187,11 +29,8 @@ async fn main() -> Result<()> {
     let markdown_files = collect_markdown_files(&target_dir)?;
 
     let index_dir = env::temp_dir().join("terrain-index");
-    let engine = Traverze::new_in_dir_for_indexing(&index_dir, TokenizerMode::LinderaIpadic, true)
-        .context("traverze index initialization failed")?;
-    let indexed = engine
-        .index_files(&markdown_files)
-        .context("failed to index markdown files")?;
+    let (engine, indexed) = build_engine(&index_dir, &markdown_files)
+        .context("failed to build search engine")?;
 
     eprintln!(
         "indexed {} markdown files from {}",
@@ -204,47 +43,4 @@ async fn main() -> Result<()> {
         .await?;
     server.waiting().await?;
     Ok(())
-}
-
-fn resolve_dir(dir: &Path) -> Result<PathBuf> {
-    let canonical =
-        fs::canonicalize(dir).with_context(|| format!("directory not found: {}", dir.display()))?;
-
-    if !canonical.is_dir() {
-        bail!("not a directory: {}", canonical.display());
-    }
-
-    Ok(canonical)
-}
-
-fn collect_markdown_files(base_dir: &Path) -> Result<Vec<PathBuf>> {
-    let mut stack = vec![base_dir.to_path_buf()];
-    let mut files = Vec::new();
-
-    while let Some(dir) = stack.pop() {
-        for entry in fs::read_dir(&dir)
-            .with_context(|| format!("failed to read directory: {}", dir.display()))?
-        {
-            let entry = entry?;
-            let path = entry.path();
-            let file_type = entry.file_type()?;
-
-            if file_type.is_dir() {
-                stack.push(path);
-                continue;
-            }
-
-            if file_type.is_file()
-                && path
-                    .extension()
-                    .and_then(|ext| ext.to_str())
-                    .map(|ext| ext.eq_ignore_ascii_case("md"))
-                    .unwrap_or(false)
-            {
-                files.push(path);
-            }
-        }
-    }
-
-    Ok(files)
 }


### PR DESCRIPTION
# feat: extract core logic into library crate (EN)

## Summary

- Extracted core logic (`TerrainServer`, `Config`, utility functions) from `main.rs` into `lib.rs`, making it available as a library for external crates
- Made `clap` an optional dependency behind the `cli` feature (enabled by default). Library consumers can exclude clap via `default-features = false`
- Simplified `main.rs` to a thin entry point that only handles CLI parsing and delegates to lib

## Motivation

Lay the groundwork for reusing terrain's MCP server functionality as a library from another project (a Tauri-based markdown viewer).

## Changes

### `Cargo.toml`
- Added `[[bin]]` section with `required-features = ["cli"]`
- Added `[features]` section: `default = ["cli"]`, `cli = ["dep:clap"]`
- Changed `clap` to `optional = true`

### `src/lib.rs` (new)
- `Config` — TOML config file loading
- `TerrainServer` — MCP server handler (`search`, `read_file` tools)
- `resolve_dir()` — directory path canonicalization and validation
- `collect_markdown_files()` — recursive Markdown file collection
- `build_engine()` — Traverze search engine construction and indexing

### `src/main.rs`
- Removed core logic, replaced with imports from `terrain::*`
- Reduced to: CLI parsing -> lib function calls -> server startup

## Usage

```toml
# As a CLI (default, same as before)
cargo build  # default features include cli

# As a library (e.g. from a Tauri app)
[dependencies]
terrain = { path = "../terrain", default-features = false }
```

## Test plan

- [x] `cargo check` — builds successfully with default features (CLI)
- [x] `cargo check --no-default-features` — builds successfully as library only

---

# feat: extract core logic into library crate (JA)

## Summary

- `main.rs` にあったコアロジック（`TerrainServer`, `Config`, ユーティリティ関数）を `lib.rs` に分離し、外部クレートからライブラリとして利用可能にした
- `clap` を optional 依存に変更し、`cli` feature（default）の背後に配置。ライブラリとして利用する場合は `default-features = false` で clap を除外できる
- `main.rs` は CLI パースと lib 呼び出しのみの薄いエントリポイントに簡素化

## Motivation

別プロジェクト（Tauri 製 markdown viewer）から terrain の MCP サーバー機能をライブラリとして利用するための基盤整備。

## Changes

### `Cargo.toml`
- `[[bin]]` セクションを追加し `required-features = ["cli"]` を指定
- `[features]` セクションを追加: `default = ["cli"]`, `cli = ["dep:clap"]`
- `clap` を `optional = true` に変更

### `src/lib.rs` (新規)
- `Config` — TOML 設定ファイルの読み込み
- `TerrainServer` — MCP サーバーハンドラ（`search`, `read_file` ツール）
- `resolve_dir()` — ディレクトリパスの正規化・検証
- `collect_markdown_files()` — Markdown ファイルの再帰的収集
- `build_engine()` — Traverze 検索エンジンの構築・インデックス作成

### `src/main.rs`
- コアロジックを削除し、`terrain::*` からの import に置き換え
- CLI パース → lib 関数呼び出し → サーバー起動のみの薄い構成に変更

## Usage

```toml
# CLI として使う場合（従来通り）
cargo build  # default features に cli が含まれる

# ライブラリとして使う場合（例: Tauri アプリ）
[dependencies]
terrain = { path = "../terrain", default-features = false }
```

## Test plan

- [x] `cargo check` — default features（CLI）でビルド成功
- [x] `cargo check --no-default-features` — ライブラリのみでビルド成功
