### PR TITLE
improve readme.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,31 @@ To build the project from the source, you need to have Rust installed.
     ```
     The executable will be located at `target/release/terrain`.
 
+## Using as a Library
+
+`terrain` can also be used as a Rust library crate by disabling the default `cli` feature:
+
+```toml
+[dependencies]
+terrain = { git = "<repository-url>", default-features = false }
+```
+
+The library exposes the following public API:
+
+- `Config` — Load and parse a TOML configuration file.
+- `TerrainServer` — The MCP server handler, ready to be plugged into an `rmcp` transport.
+- `resolve_dir` / `collect_markdown_files` / `build_engine` — Utility functions for directory resolution, Markdown file collection, and search engine initialization.
+
+## Configuration
+
+In MCP, tool descriptions directly influence how the AI model decides when and how to use each tool. You can customize these descriptions to better suit your use case by providing a TOML configuration file.
+
+```bash
+terrain --dir /path/to/your/notes --config terrain.config.toml
+```
+
+See [terrain.config.example.toml](terrain.config.example.toml) for all available options.
+
 ## MCP Tools
 
 The server provides the following tools:

--- a/README.md
+++ b/README.md
@@ -1,52 +1,16 @@
 # terrain
 
-`terrain` is a high-performance, local-first full-text search engine for your Markdown knowledge base, optimized for Japanese text.
+`terrain` is a lightweight, local-first full-text search engine for your Markdown knowledge base, with built-in support for Japanese text.
 
-It runs as a command-line MCP (Model Context Protocol) server, indexing a specified directory of `.md` files and exposing powerful search and retrieval tools.
+It runs as a command-line MCP (Model Context Protocol) server, indexing a specified directory of `.md` files and exposing search and retrieval tools.
 
 ## Features
 
-- **Blazing-Fast Search:** Powered by the `traverze` search engine.
-- **Optimized for Japanese:** Utilizes `Lindera` with an IPADIC dictionary for accurate morphological analysis and tokenization of Japanese text.
+- **Full-Text Search:** Powered by the `traverze` search engine, built on `tantivy`.
+- **Japanese Support:** Utilizes `lindera` with an IPADIC dictionary for accurate morphological analysis and tokenization of Japanese text.
 - **MCP Server:** Exposes a simple, machine-readable tool interface over standard I/O.
 - **Secure:** File access is restricted to the indexed directory to prevent unauthorized access.
 - **Cross-Platform:** Built with Rust, runs on Windows, macOS, and Linux.
-
-## Usage
-
-1.  **Start the server:**
-    Run the program from your terminal, pointing it to the directory containing your Markdown files.
-
-    ```bash
-    terrain --dir /path/to/your/notes
-    ```
-
-2.  **Indexing:**
-    The server will first index all Markdown files in the specified directory. You will see a message indicating how many files have been indexed.
-
-    ```
-    indexed 1234 markdown files from /path/to/your/notes
-    ```
-
-3.  **Interact via MCP:**
-    Once indexed, the server listens on `stdin` for MCP JSON requests and sends responses to `stdout`. You can use this interface with any MCP-compatible client or controller.
-
-## MCP Client Setup
-
-To use `terrain` with an MCP-compatible client such as Claude Desktop, add the following to your client's configuration file (e.g., `claude_desktop_config.json`):
-
-```json
-{
-  "mcpServers": {
-    "terrain": {
-      "command": "terrain",
-      "args": ["--dir", "/path/to/your/notes"]
-    }
-  }
-}
-```
-
-If you built from source without `cargo install`, use the full path to the executable instead (e.g., `"/path/to/terrain"`).
 
 ## Installation
 
@@ -72,6 +36,42 @@ The library exposes the following public API:
 - `Config` — Load and parse a TOML configuration file.
 - `TerrainServer` — The MCP server handler, ready to be plugged into an `rmcp` transport.
 - `resolve_dir` / `collect_markdown_files` / `build_engine` — Utility functions for directory resolution, Markdown file collection, and search engine initialization.
+
+## MCP Client Setup
+
+To use `terrain` with an MCP-compatible client such as Claude Desktop, add the following to your client's configuration file (e.g., `claude_desktop_config.json`):
+
+```json
+{
+  "mcpServers": {
+    "terrain": {
+      "command": "terrain",
+      "args": ["--dir", "/path/to/your/notes"]
+    }
+  }
+}
+```
+
+If you built from source without `cargo install`, use the full path to the executable instead (e.g., `"/path/to/terrain"`).
+
+## Usage
+
+1.  **Start the server:**
+    Run the program from your terminal, pointing it to the directory containing your Markdown files.
+
+    ```bash
+    terrain --dir /path/to/your/notes
+    ```
+
+2.  **Indexing:**
+    The server will first index all Markdown files in the specified directory. You will see a message indicating how many files have been indexed.
+
+    ```
+    indexed 1234 markdown files from /path/to/your/notes
+    ```
+
+3.  **Interact via MCP:**
+    Once indexed, the server listens on `stdin` for MCP JSON requests and sends responses to `stdout`. You can use this interface with any MCP-compatible client or controller.
 
 ## Configuration
 

--- a/README.md
+++ b/README.md
@@ -31,6 +31,23 @@ It runs as a command-line MCP (Model Context Protocol) server, indexing a specif
 3.  **Interact via MCP:**
     Once indexed, the server listens on `stdin` for MCP JSON requests and sends responses to `stdout`. You can use this interface with any MCP-compatible client or controller.
 
+## MCP Client Setup
+
+To use `terrain` with an MCP-compatible client such as Claude Desktop, add the following to your client's configuration file (e.g., `claude_desktop_config.json`):
+
+```json
+{
+  "mcpServers": {
+    "terrain": {
+      "command": "terrain",
+      "args": ["--dir", "/path/to/your/notes"]
+    }
+  }
+}
+```
+
+If you built from source without `cargo install`, use the full path to the executable instead (e.g., `"/path/to/terrain"`).
+
 ## Building
 
 To build the project from the source, you need to have Rust installed.

--- a/README.md
+++ b/README.md
@@ -48,25 +48,19 @@ To use `terrain` with an MCP-compatible client such as Claude Desktop, add the f
 
 If you built from source without `cargo install`, use the full path to the executable instead (e.g., `"/path/to/terrain"`).
 
-## Building
+## Installation
 
-To build the project from the source, you need to have Rust installed.
+You need to have [Rust](https://www.rust-lang.org/tools/install) installed.
 
-1.  Clone the repository:
-    ```bash
-    git clone <repository-url>
-    cd terrain
-    ```
+### As a CLI tool
 
-2.  Build the project:
-    ```bash
-    cargo build --release
-    ```
-    The executable will be located at `target/release/terrain`.
+```bash
+cargo install --git <repository-url>
+```
 
-## Using as a Library
+### As a library
 
-`terrain` can also be used as a Rust library crate by disabling the default `cli` feature:
+Add the following to your `Cargo.toml`:
 
 ```toml
 [dependencies]

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # terrain
 
-`terrain` is a lightweight, local-first full-text search engine for your Markdown knowledge base, with built-in support for Japanese text.
+`terrain` is a lightweight, configurable, local-first full-text search engine for your Markdown knowledge base, with built-in support for Japanese text.
 
 It runs as a command-line MCP (Model Context Protocol) server, indexing a specified directory of `.md` files and exposing search and retrieval tools.
 
@@ -10,6 +10,7 @@ It runs as a command-line MCP (Model Context Protocol) server, indexing a specif
 - **Japanese Support:** Utilizes `lindera` with an IPADIC dictionary for accurate morphological analysis and tokenization of Japanese text.
 - **MCP Server:** Exposes a simple, machine-readable tool interface over standard I/O.
 - **Secure:** File access is restricted to the indexed directory to prevent unauthorized access.
+- **Configurable:** Customize tool descriptions via a TOML configuration file to tailor AI model behavior.
 - **Cross-Platform:** Built with Rust, runs on Windows, macOS, and Linux.
 
 ## Installation


### PR DESCRIPTION
## Summary

- Revised wording throughout README to remove exaggerated claims ("high-performance" → "lightweight", "Blazing-Fast" → "Full-Text Search", "Optimized for Japanese" → "Japanese Support", removed "powerful")
- Replaced `Building` section with `Installation` section, adding `cargo install` instructions
- Added library usage example with `Cargo.toml` dependency and public API documentation
- Added `MCP Client Setup` section with Claude Desktop configuration example
- Added `Configuration` section describing `--config` option and linking to `terrain.config.example.toml`
- Unified crate name casing to lowercase (`Tantivy` → `tantivy`, `Lindera` → `lindera`)

## Test plan

- [x] Verify all command examples in README work correctly — `terrain --dir <path>` and `terrain --dir <path> --config terrain.config.example.toml` both start successfully, index files, and respond to MCP initialize request
- [x] Verify link to `terrain.config.example.toml` is valid — file exists at repository root
- [x] Verify MCP Client Setup configuration example is valid JSON — confirmed valid structure

---

## Summary (日本語)

- README全体の表現を見直し、誇大な表現を修正（"high-performance" → "lightweight"、"Blazing-Fast" → "Full-Text Search"、"Optimized for Japanese" → "Japanese Support"、"powerful" を削除）
- `Building` セクションを `Installation` セクションに変更し、`cargo install` によるインストール方法を追加
- ライブラリとして利用する場合の `Cargo.toml` 記載例と公開APIの説明を追加
- MCPクライアント（Claude Desktop等）での設定例を `MCP Client Setup` セクションとして追加
- `Configuration` セクションを追加し、`--config` オプションによるツール説明のカスタマイズ方法と `terrain.config.example.toml` へのリンクを記載
- クレート名の表記を小文字に統一（`Tantivy` → `tantivy`、`Lindera` → `lindera`）

## Test plan (日本語)

- [x] READMEの各コマンド例が正しく動作することを確認 — `terrain --dir <path>` および `--config` 付きで起動・インデックス・MCP応答を確認済み
- [x] `terrain.config.example.toml` へのリンクが有効であることを確認 — リポジトリルートにファイル存在を確認済み
- [x] MCP Client Setup の設定例が正しいJSON形式であることを確認 — 構造が正しいことを確認済み
