### PR TITLE
notify when indexing is complete

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
 /target
+.vscode/
+.claude/

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 /target
 .vscode/
 .claude/
+.mcp.json

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,8 +4,9 @@ use std::path::{Path, PathBuf};
 use anyhow::{Context, Result, bail};
 use rmcp::handler::server::tool::ToolRouter;
 use rmcp::handler::server::wrapper::Parameters;
-use rmcp::model::{ServerCapabilities, ServerInfo};
-use rmcp::{ServerHandler, tool, tool_handler, tool_router};
+use rmcp::model::{LoggingLevel, LoggingMessageNotificationParam, ServerCapabilities, ServerInfo};
+use rmcp::service::NotificationContext;
+use rmcp::{RoleServer, ServerHandler, tool, tool_handler, tool_router};
 use schemars::JsonSchema;
 use serde::Deserialize;
 use traverze::{SearchOptions, SnippetOptions, TokenizerMode, Traverze};
@@ -62,6 +63,7 @@ pub struct TerrainServer {
     base_dir: PathBuf,
     tool_router: ToolRouter<Self>,
     instructions: String,
+    indexed_count: usize,
 }
 
 #[tool_router]
@@ -125,10 +127,37 @@ impl ServerHandler for TerrainServer {
             ..Default::default()
         }
     }
+
+    fn on_initialized(
+        &self,
+        context: NotificationContext<RoleServer>,
+    ) -> impl std::future::Future<Output = ()> + Send + '_ {
+        let peer = context.peer.clone();
+        let message = format!(
+            "indexed {} markdown files from {}",
+            self.indexed_count,
+            self.base_dir.display()
+        );
+        async move {
+            // Spawn as a background task to avoid blocking `on_initialized`.
+            // Some MCP clients (e.g. Claude Code) won't process `tools/list`
+            // until this handler returns, so a blocking `notify_logging_message`
+            // causes tool discovery to time out.
+            tokio::spawn(async move {
+                let _ = peer
+                    .notify_logging_message(LoggingMessageNotificationParam {
+                        level: LoggingLevel::Info,
+                        data: serde_json::json!(message),
+                        logger: Some("terrain".to_string()),
+                    })
+                    .await;
+            });
+        }
+    }
 }
 
 impl TerrainServer {
-    pub fn new(engine: Traverze, base_dir: PathBuf, config: &Config) -> Self {
+    pub fn new(engine: Traverze, base_dir: PathBuf, config: &Config, indexed_count: usize) -> Self {
         let mut router = Self::tool_router();
 
         if let Some(desc) = &config.search_description {
@@ -151,6 +180,7 @@ impl TerrainServer {
             base_dir,
             tool_router: router,
             instructions,
+            indexed_count,
         }
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -38,7 +38,7 @@ async fn main() -> Result<()> {
         target_dir.display()
     );
 
-    let server = TerrainServer::new(engine, target_dir, &config)
+    let server = TerrainServer::new(engine, target_dir, &config, indexed)
         .serve(stdio())
         .await?;
     server.waiting().await?;


### PR DESCRIPTION
## Summary

Add a notification feature that reports the number of indexed Markdown files to MCP clients when indexing is complete.

- Implement `on_initialized` handler to send the indexed file count and base directory via MCP `notifications/message` (logging)
- Use `tokio::spawn` for background sending to prevent `tools/list` timeout on clients like Claude Code
- Add `.vscode/`, `.claude/`, `.mcp.json` to `.gitignore`

## Changes

### `src/lib.rs`
- Add `indexed_count` field to `TerrainServer`
- Implement `ServerHandler::on_initialized` to send an Info-level log notification via `notify_logging_message`
- Add `indexed_count` parameter to `TerrainServer::new`

### `src/main.rs`
- Pass `indexed` (number of indexed files) to `TerrainServer::new`

### `.gitignore`
- Add `.vscode/`, `.claude/`, `.mcp.json`

## Test plan

- [x] `cargo build` succeeds
- [x] After connecting with an MCP client (e.g. Claude Code), a log notification is received upon initialization
- [x] The number of indexed Markdown files is displayed correctly
- [x] `tools/list` returns without timing out

---

## Summary (日本語)

インデックス完了時に、インデックスされたMarkdownファイル数をMCPクライアントへ通知する機能を追加します。

- `on_initialized` ハンドラを実装し、MCP の `notifications/message` (logging) を使ってインデックス済みファイル数とベースディレクトリを通知
- `tokio::spawn` でバックグラウンド送信することで、Claude Code などのクライアントで `tools/list` のタイムアウトが発生しないよう対処
- `.gitignore` に `.vscode/`、`.claude/`、`.mcp.json` を追加

## Changes (日本語)

### `src/lib.rs`
- `TerrainServer` に `indexed_count` フィールドを追加
- `ServerHandler::on_initialized` を実装し、`notify_logging_message` で Info レベルのログ通知を送信
- `TerrainServer::new` の引数に `indexed_count` を追加

### `src/main.rs`
- `TerrainServer::new` 呼び出しに `indexed` (インデックス済みファイル数) を渡すよう変更

### `.gitignore`
- `.vscode/`、`.claude/`、`.mcp.json` を追加

## Test plan (日本語)

- [x] `cargo build` が成功すること
- [x] MCP クライアント (Claude Code 等) で接続し、初期化後にログ通知が届くこと
- [x] インデックス対象のMarkdownファイル数が正しく表示されること
- [x] `tools/list` がタイムアウトせずに返ること
