### PR TITLE
auto index on directory changes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -185,7 +185,7 @@ version = "3.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d314cc62af2b6b0c65780555abb4d02a03dd3b799cd42419044f0c38d99738c0"
 dependencies = [
- "darling 0.23.0",
+ "darling 0.20.11",
  "ident_case",
  "prettyplease",
  "proc-macro2",
@@ -762,6 +762,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42703706b716c37f96a77aea830392ad231f44c9e9a67872fa5548707e11b11c"
 
 [[package]]
+name = "fsevent-sys"
+version = "4.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76ee7a02da4d231650c7cea31349b889be2f45ddb3ef3032d2ec8185f6313fd2"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "futures"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1189,6 +1198,35 @@ dependencies = [
 ]
 
 [[package]]
+name = "inotify"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fdd168d97690d0b8c412d6b6c10360277f4d7ee495c5d0d5d5fe0854923255cc"
+dependencies = [
+ "bitflags 1.3.2",
+ "inotify-sys",
+ "libc",
+]
+
+[[package]]
+name = "inotify-sys"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e05c02b5e89bff3b946cedeca278abc628fe811e604f027c45a8aa3cf793d0eb"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "instant"
+version = "0.1.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e0242819d153cba4b4b05a5a8f2a7e9bbf97b6055b2a002b395c96b5ff3c0222"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
 name = "ipnet"
 version = "2.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1274,6 +1312,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c0f9d9652540055ac4fded998a73aca97d965899077ab1212587437da44196ff"
 dependencies = [
  "bitflags 1.3.2",
+]
+
+[[package]]
+name = "kqueue"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eac30106d7dce88daf4a3fcb4879ea939476d5074a9b7ddd0fb97fa4bed5596a"
+dependencies = [
+ "kqueue-sys",
+ "libc",
+]
+
+[[package]]
+name = "kqueue-sys"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed9625ffda8729b85e45cf04090035ac368927b8cebc34898e7c120f52e4838b"
+dependencies = [
+ "bitflags 1.3.2",
+ "libc",
 ]
 
 [[package]]
@@ -1561,6 +1619,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a69bcab0ad47271a0234d9422b131806bf3968021e5dc9328caf2d4cd58557fc"
 dependencies = [
  "libc",
+ "log",
  "wasi",
  "windows-sys 0.61.2",
 ]
@@ -1599,6 +1658,34 @@ checksum = "d273983c5a657a70a3e8f2a01329822f3b8c8172b73826411a55751e404a0a4a"
 dependencies = [
  "memchr",
  "minimal-lexical",
+]
+
+[[package]]
+name = "notify"
+version = "7.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c533b4c39709f9ba5005d8002048266593c1cfaf3c5f0739d5b8ab0c6c504009"
+dependencies = [
+ "bitflags 2.11.0",
+ "filetime",
+ "fsevent-sys",
+ "inotify",
+ "kqueue",
+ "libc",
+ "log",
+ "mio",
+ "notify-types",
+ "walkdir",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "notify-types"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "585d3cb5e12e01aed9e8a1f70d5c6b5e86fe2a6e48fc8cd0b3e0b8df6f6eb174"
+dependencies = [
+ "instant",
 ]
 
 [[package]]
@@ -2684,6 +2771,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "clap",
+ "notify",
  "rmcp",
  "schemars",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,4 +27,5 @@ serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 tokio = { version = "1.47.1", features = ["macros", "rt-multi-thread"] }
 toml = "0.8"
+notify = "7"
 traverze = { version = "0.2.0", features = ["tokenizer-lindera-ipadic"] }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,7 +1,9 @@
 use std::fs;
 use std::path::{Path, PathBuf};
+use std::time::Duration;
 
 use anyhow::{Context, Result, bail};
+use notify::{EventKind, RecommendedWatcher, RecursiveMode, Watcher};
 use rmcp::handler::server::tool::ToolRouter;
 use rmcp::handler::server::wrapper::Parameters;
 use rmcp::model::{LoggingLevel, LoggingMessageNotificationParam, ServerCapabilities, ServerInfo};
@@ -240,4 +242,74 @@ pub fn build_engine(index_dir: &Path, files: &[PathBuf]) -> Result<(Traverze, us
         .index_files(files)
         .context("failed to index markdown files")?;
     Ok((engine, indexed))
+}
+
+/// Start watching the directory for file changes and update the index accordingly.
+///
+/// Returns the [`RecommendedWatcher`] handle. The watcher stops when this
+/// handle is dropped, so keep it alive for the lifetime of the server.
+pub fn start_watcher(engine: Traverze, base_dir: PathBuf) -> Result<RecommendedWatcher> {
+    let (tx, rx) = std::sync::mpsc::channel();
+
+    let mut watcher = RecommendedWatcher::new(
+        move |res: std::result::Result<notify::Event, notify::Error>| {
+            if let Ok(event) = res {
+                let _ = tx.send(event);
+            }
+        },
+        notify::Config::default().with_poll_interval(Duration::from_secs(2)),
+    )
+    .context("failed to create file watcher")?;
+
+    watcher
+        .watch(base_dir.as_ref(), RecursiveMode::Recursive)
+        .with_context(|| format!("failed to watch directory: {}", base_dir.display()))?;
+
+    tokio::spawn(async move {
+        tokio::task::spawn_blocking(move || {
+            while let Ok(event) = rx.recv() {
+                let md_paths: Vec<PathBuf> = event
+                    .paths
+                    .into_iter()
+                    .filter(|p| is_markdown(p))
+                    .collect();
+
+                if md_paths.is_empty() {
+                    continue;
+                }
+
+                match event.kind {
+                    EventKind::Create(_) => {
+                        match engine.index_files(&md_paths) {
+                            Ok(n) => eprintln!("watcher: indexed {} new file(s)", n),
+                            Err(e) => eprintln!("watcher: index error: {e}"),
+                        }
+                    }
+                    EventKind::Modify(_) => {
+                        let _ = engine.remove_files(&md_paths);
+                        match engine.index_files(&md_paths) {
+                            Ok(n) => eprintln!("watcher: re-indexed {} file(s)", n),
+                            Err(e) => eprintln!("watcher: re-index error: {e}"),
+                        }
+                    }
+                    EventKind::Remove(_) => {
+                        match engine.remove_files(&md_paths) {
+                            Ok(n) => eprintln!("watcher: removed {} file(s) from index", n),
+                            Err(e) => eprintln!("watcher: remove error: {e}"),
+                        }
+                    }
+                    _ => {}
+                }
+            }
+        });
+    });
+
+    Ok(watcher)
+}
+
+fn is_markdown(path: &Path) -> bool {
+    path.extension()
+        .and_then(|ext| ext.to_str())
+        .map(|ext| ext.eq_ignore_ascii_case("md"))
+        .unwrap_or(false)
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,6 +4,7 @@ use std::path::{Path, PathBuf};
 use std::time::Duration;
 
 use anyhow::{Context, Result, bail};
+use notify::event::{CreateKind, RemoveKind, RenameMode};
 use notify::{EventKind, RecommendedWatcher, RecursiveMode, Watcher};
 use rmcp::handler::server::tool::ToolRouter;
 use rmcp::handler::server::wrapper::Parameters;
@@ -328,10 +329,65 @@ pub fn start_watcher(engine: Traverze, base_dir: PathBuf) -> Result<RecommendedW
 
 /// Accumulate file-system events into `pending`, keeping only the latest
 /// [`EventKind`] per path and filtering to Markdown files.
+///
+/// Rename events are normalised into Remove / Create so that the processing
+/// loop does not need to know about renames.
 fn accumulate(pending: &mut HashMap<PathBuf, EventKind>, event: &notify::Event) {
-    for path in &event.paths {
-        if is_markdown(path) {
-            pending.insert(path.clone(), event.kind.clone());
+    match &event.kind {
+        EventKind::Modify(notify::event::ModifyKind::Name(mode)) => {
+            match mode {
+                // "From" carries the old path → treat as removal.
+                RenameMode::From => {
+                    if let Some(old) = event.paths.first() {
+                        if is_markdown(old) {
+                            pending.insert(old.clone(), EventKind::Remove(RemoveKind::File));
+                        }
+                    }
+                }
+                // "To" carries the new path → treat as creation.
+                RenameMode::To => {
+                    if let Some(new) = event.paths.first() {
+                        if is_markdown(new) {
+                            pending.insert(new.clone(), EventKind::Create(CreateKind::File));
+                        }
+                    }
+                }
+                // "Both" carries [old, new] in a single event.
+                RenameMode::Both => {
+                    if let Some(old) = event.paths.first() {
+                        if is_markdown(old) {
+                            pending.insert(old.clone(), EventKind::Remove(RemoveKind::File));
+                        }
+                    }
+                    if let Some(new) = event.paths.get(1) {
+                        if is_markdown(new) {
+                            pending.insert(new.clone(), EventKind::Create(CreateKind::File));
+                        }
+                    }
+                }
+                // "Any" / "Other" – direction unknown. If the file exists now
+                // treat it as a creation; otherwise as a removal.
+                _ => {
+                    for path in &event.paths {
+                        if is_markdown(path) {
+                            let kind = if path.exists() {
+                                EventKind::Create(CreateKind::File)
+                            } else {
+                                EventKind::Remove(RemoveKind::File)
+                            };
+                            pending.insert(path.clone(), kind);
+                        }
+                    }
+                }
+            }
+        }
+        // Non-rename events: pass through as-is.
+        _ => {
+            for path in &event.paths {
+                if is_markdown(path) {
+                    pending.insert(path.clone(), event.kind.clone());
+                }
+            }
         }
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,4 @@
+use std::collections::HashMap;
 use std::fs;
 use std::path::{Path, PathBuf};
 use std::time::Duration;
@@ -267,44 +268,72 @@ pub fn start_watcher(engine: Traverze, base_dir: PathBuf) -> Result<RecommendedW
 
     tokio::spawn(async move {
         tokio::task::spawn_blocking(move || {
-            while let Ok(event) = rx.recv() {
-                let md_paths: Vec<PathBuf> = event
-                    .paths
-                    .into_iter()
-                    .filter(|p| is_markdown(p))
-                    .collect();
+            let debounce = Duration::from_millis(500);
+            let mut pending: HashMap<PathBuf, EventKind> = HashMap::new();
 
-                if md_paths.is_empty() {
-                    continue;
+            loop {
+                // Wait for the first event (blocking).
+                let event = match rx.recv() {
+                    Ok(e) => e,
+                    Err(_) => break,
+                };
+                accumulate(&mut pending, &event);
+
+                // Drain further events until the channel is quiet for `debounce`.
+                loop {
+                    match rx.recv_timeout(debounce) {
+                        Ok(e) => accumulate(&mut pending, &e),
+                        Err(std::sync::mpsc::RecvTimeoutError::Timeout) => break,
+                        Err(std::sync::mpsc::RecvTimeoutError::Disconnected) => break,
+                    }
                 }
 
-                match event.kind {
-                    EventKind::Create(_) => {
-                        match engine.index_files(&md_paths) {
-                            Ok(n) => eprintln!("watcher: indexed {} new file(s)", n),
-                            Err(e) => eprintln!("watcher: index error: {e}"),
-                        }
+                // Process batched events.
+                let to_index: Vec<PathBuf> = pending
+                    .iter()
+                    .filter(|(_, kind)| {
+                        matches!(kind, EventKind::Create(_) | EventKind::Modify(_))
+                    })
+                    .map(|(path, _)| path.clone())
+                    .collect();
+
+                let to_remove: Vec<PathBuf> = pending
+                    .iter()
+                    .filter(|(_, kind)| matches!(kind, EventKind::Remove(_)))
+                    .map(|(path, _)| path.clone())
+                    .collect();
+
+                pending.clear();
+
+                if !to_remove.is_empty() {
+                    match engine.remove_files(&to_remove) {
+                        Ok(n) => eprintln!("watcher: removed {} file(s) from index", n),
+                        Err(e) => eprintln!("watcher: remove error: {e}"),
                     }
-                    EventKind::Modify(_) => {
-                        let _ = engine.remove_files(&md_paths);
-                        match engine.index_files(&md_paths) {
-                            Ok(n) => eprintln!("watcher: re-indexed {} file(s)", n),
-                            Err(e) => eprintln!("watcher: re-index error: {e}"),
-                        }
+                }
+
+                if !to_index.is_empty() {
+                    let _ = engine.remove_files(&to_index);
+                    match engine.index_files(&to_index) {
+                        Ok(n) => eprintln!("watcher: re-indexed {} file(s)", n),
+                        Err(e) => eprintln!("watcher: re-index error: {e}"),
                     }
-                    EventKind::Remove(_) => {
-                        match engine.remove_files(&md_paths) {
-                            Ok(n) => eprintln!("watcher: removed {} file(s) from index", n),
-                            Err(e) => eprintln!("watcher: remove error: {e}"),
-                        }
-                    }
-                    _ => {}
                 }
             }
         });
     });
 
     Ok(watcher)
+}
+
+/// Accumulate file-system events into `pending`, keeping only the latest
+/// [`EventKind`] per path and filtering to Markdown files.
+fn accumulate(pending: &mut HashMap<PathBuf, EventKind>, event: &notify::Event) {
+    for path in &event.paths {
+        if is_markdown(path) {
+            pending.insert(path.clone(), event.kind.clone());
+        }
+    }
 }
 
 fn is_markdown(path: &Path) -> bool {

--- a/src/main.rs
+++ b/src/main.rs
@@ -4,7 +4,7 @@ use std::path::PathBuf;
 use anyhow::{Context, Result};
 use clap::Parser;
 use rmcp::{ServiceExt, transport::stdio};
-use terrain::{Config, TerrainServer, build_engine, collect_markdown_files, resolve_dir};
+use terrain::{Config, TerrainServer, build_engine, collect_markdown_files, resolve_dir, start_watcher};
 
 /// terrain MCP server – Markdown full-text search
 #[derive(Parser)]
@@ -37,6 +37,10 @@ async fn main() -> Result<()> {
         indexed,
         target_dir.display()
     );
+
+    let _watcher = start_watcher(engine.clone(), target_dir.clone())
+        .context("failed to start file watcher")?;
+    eprintln!("watching {} for changes", target_dir.display());
 
     let server = TerrainServer::new(engine, target_dir, &config, indexed)
         .serve(stdio())


### PR DESCRIPTION
# Add file watcher to auto-update index on directory changes

## Summary

Add a file system watcher that monitors the indexed directory for Markdown file changes and automatically updates the search index at runtime. Previously, the index was only built once at startup; now it stays in sync as files are created, modified, deleted, or renamed.

## Changes

- Add `notify` v7 crate dependency for cross-platform file system event monitoring
- Implement `start_watcher()` that recursively watches the target directory using `RecommendedWatcher`
- Debounce rapid file system events (500ms quiet period) and batch-process them to avoid redundant index operations
- Normalize rename events (`From`/`To`/`Both`/`Any`) into `Remove`/`Create` so all event types are handled uniformly
- Wire up the watcher in `main.rs`, keeping the handle alive for the server lifetime

---

## 概要

インデックス対象ディレクトリのファイル変更を監視し、検索インデックスを実行時に自動更新するファイルウォッチャーを追加。従来は起動時に一度だけインデックスを構築していたが、これによりファイルの作成・変更・削除・リネームにリアルタイムで追従できるようになった。

## 変更内容

- クロスプラットフォームのファイル監視ライブラリ `notify` v7 を依存に追加
- `start_watcher()` を実装し、`RecommendedWatcher` で対象ディレクトリを再帰的に監視
- 短時間の連続イベントをデバウンス（500ms）してバッチ処理し、不要なインデックス操作を回避
- リネームイベント（`From`/`To`/`Both`/`Any`）を `Remove`/`Create` に正規化し、全イベント種別を統一的に処理
- `main.rs` でウォッチャーを起動し、サーバーのライフタイム中ハンドルを保持
