### PR TITLE
create changelog

### DIFF
--- a/CHANGELOG.ja.md
+++ b/CHANGELOG.ja.md
@@ -1,0 +1,31 @@
+# 変更履歴
+
+このプロジェクトに対するすべての重要な変更はこのファイルに記録されます。
+
+このフォーマットは [Keep a Changelog](https://keepachangelog.com/ja/1.1.0/) に基づいており、
+このプロジェクトは [Semantic Versioning](https://semver.org/lang/ja/spec/v2.0.0.html) に準拠しています。
+
+## [Unreleased]
+
+### Added
+
+- ディレクトリの変更を監視してインデックスを自動更新するファイルウォッチャーを追加
+- デバウンス処理によるイベントのバッチ処理で効率的なインデックス更新を実現
+- ファイルウォッチャーでリネームイベントの正規化に対応
+- インデックス完了時にインデックス済みドキュメント数をログ出力する機能を追加
+
+## [0.1.0] - 2026-03-15
+
+### Added
+
+- 全文検索機能を備えた Markdown インデックスサーバー
+- `search` と `read_file` ツールを持つ stdio MCP サーバー
+- `clap` によるコマンドライン引数のパース
+- TOML ファイルによる MCP サーバー説明文の設定機能
+- MCP サーバーの設定ファイル例
+- コアロジックをライブラリクレートとして切り出し、依存ライブラリとして利用可能に
+- `clap` 依存をオプショナルにする `cli` フィーチャーフラグ
+- Apache 2.0 および MIT デュアルライセンス
+
+[unreleased]: https://github.com/kyow/terrain/compare/v0.1.0...HEAD
+[0.1.0]: https://github.com/kyow/terrain/releases/tag/v0.1.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,31 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+### Added
+
+- File watcher to monitor directory changes and automatically update the index
+- Debounced event handling with batch processing for efficient indexing
+- Rename event normalization in file watcher
+- Logging of indexed document count when indexing is complete
+
+## [0.1.0] - 2026-03-15
+
+### Added
+
+- Markdown indexing server with full-text search capabilities
+- stdio MCP server with `search` and `read_file` tools
+- Command-line argument parsing with `clap`
+- Configurable MCP server instructions via TOML file
+- Example configuration file for MCP server
+- Library crate for core logic, enabling use as a dependency
+- Optional `cli` feature flag for `clap` dependency
+- Apache 2.0 and MIT dual license
+
+[unreleased]: https://github.com/kyow/terrain/compare/v0.1.0...HEAD
+[0.1.0]: https://github.com/kyow/terrain/releases/tag/v0.1.0


### PR DESCRIPTION
# Add CHANGELOG following Keep a Changelog 1.1.0

## Summary

Introduce `CHANGELOG.md` and `CHANGELOG.ja.md` to document notable project changes for users. The format follows [Keep a Changelog 1.1.0](https://keepachangelog.com/en/1.1.0/) and the project adheres to Semantic Versioning.

## Motivation

Provide a human-readable record of user-facing changes across releases, so users can quickly understand what was added or modified in each version without reading the git log.

## Changes

- Added `CHANGELOG.md` (English) with `[Unreleased]` and `[0.1.0]` sections
- Added `CHANGELOG.ja.md` (Japanese translation) with matching structure
- `[0.1.0]` lists the initial release features (Markdown indexing, MCP server, configurable instructions, library crate, CLI feature flag, dual license)
- `[Unreleased]` lists post-0.1.0 user-facing features (file watcher with debounce/batching, rename event normalization, indexing completion notification)
- Excluded chore-level commits (dependency bumps, `.gitignore` updates) and internal refactors already covered by the initial release entry

## Notes

- Release date for `0.1.0` is taken from the `v0.1.0` tag commit date (2026-03-15)
- Comparison links at the bottom point to GitHub compare / tag URLs

---

# Keep a Changelog 1.1.0 に従った CHANGELOG の追加

## 概要

ユーザー向けに重要な変更を記録するため、`CHANGELOG.md` と `CHANGELOG.ja.md` を追加した。フォーマットは [Keep a Changelog 1.1.0](https://keepachangelog.com/ja/1.1.0/) に準拠し、プロジェクトは Semantic Versioning に従う。

## 背景

各バージョンで何が追加・変更されたかを、git log を読まずにユーザーが把握できるよう、人間が読むための変更履歴を整備する。

## 変更内容

- `CHANGELOG.md`（英語）を追加し、`[Unreleased]` と `[0.1.0]` セクションを記載
- `CHANGELOG.ja.md`（日本語訳）を同じ構成で追加
- `[0.1.0]` には初回リリース時の機能（Markdown インデックス、MCP サーバー、設定可能な説明文、ライブラリクレート化、CLI フィーチャーフラグ、デュアルライセンス）を記載
- `[Unreleased]` には v0.1.0 以降のユーザー向け機能（デバウンス・バッチ処理付きファイルウォッチャー、リネームイベントの正規化、インデックス完了通知）を記載
- chore 的なコミット（依存バージョン更新、`.gitignore` 更新）や、初回リリース項目と重複する内部リファクタは除外

## 備考

- `0.1.0` のリリース日は `v0.1.0` タグのコミット日（2026-03-15）を使用
- 末尾に GitHub の compare / tag URL への比較リンクを設定
