### PR TITLE
Restrict read_file access to indexed paths

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,7 @@
+use std::collections::HashSet;
 use std::fs;
 use std::path::{Path, PathBuf};
+use std::sync::{Arc, RwLock};
 
 use anyhow::{Context, Result, bail};
 use rmcp::handler::server::tool::ToolRouter;
@@ -33,6 +35,62 @@ impl Config {
 }
 
 // ---------------------------------------------------------------------------
+// IndexedPaths
+// ---------------------------------------------------------------------------
+
+/// Shared set of paths currently registered in the search index.
+///
+/// `read_file` consults this set to decide whether a path may be read,
+/// replacing the previous "must live under base_dir" check. Registration
+/// into the index is therefore the permission grant.
+///
+/// Cheap to clone (internally `Arc`).
+#[derive(Clone, Default)]
+pub struct IndexedPaths(Arc<RwLock<HashSet<PathBuf>>>);
+
+impl IndexedPaths {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    pub fn insert(&self, path: PathBuf) {
+        self.0
+            .write()
+            .expect("indexed-paths lock poisoned")
+            .insert(path);
+    }
+
+    pub fn extend<I: IntoIterator<Item = PathBuf>>(&self, paths: I) {
+        self.0
+            .write()
+            .expect("indexed-paths lock poisoned")
+            .extend(paths);
+    }
+
+    pub fn remove(&self, path: &Path) -> bool {
+        self.0
+            .write()
+            .expect("indexed-paths lock poisoned")
+            .remove(path)
+    }
+
+    pub fn contains(&self, path: &Path) -> bool {
+        self.0
+            .read()
+            .expect("indexed-paths lock poisoned")
+            .contains(path)
+    }
+
+    pub fn len(&self) -> usize {
+        self.0.read().expect("indexed-paths lock poisoned").len()
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.0.read().expect("indexed-paths lock poisoned").is_empty()
+    }
+}
+
+// ---------------------------------------------------------------------------
 // MCP Tool parameters
 // ---------------------------------------------------------------------------
 
@@ -60,7 +118,7 @@ struct ReadFileParams {
 #[derive(Clone)]
 pub struct TerrainServer {
     engine: Traverze,
-    base_dir: PathBuf,
+    indexed_paths: IndexedPaths,
     tool_router: ToolRouter<Self>,
     instructions: String,
     indexed_count: usize,
@@ -110,8 +168,8 @@ impl TerrainServer {
         let canonical = fs::canonicalize(&params.path)
             .map_err(|e| format!("file not found: {}: {e}", params.path))?;
 
-        if !canonical.starts_with(&self.base_dir) {
-            return Err("access denied: path is outside the indexed directory".to_string());
+        if !self.indexed_paths.contains(&canonical) {
+            return Err("access denied: path is not in the index".to_string());
         }
 
         fs::read_to_string(&canonical).map_err(|e| format!("failed to read file: {e}"))
@@ -133,11 +191,7 @@ impl ServerHandler for TerrainServer {
         context: NotificationContext<RoleServer>,
     ) -> impl std::future::Future<Output = ()> + Send + '_ {
         let peer = context.peer.clone();
-        let message = format!(
-            "indexed {} markdown files from {}",
-            self.indexed_count,
-            self.base_dir.display()
-        );
+        let message = format!("indexed {} files", self.indexed_count);
         async move {
             // Spawn as a background task to avoid blocking `on_initialized`.
             // Some MCP clients (e.g. Claude Code) won't process `tools/list`
@@ -157,7 +211,12 @@ impl ServerHandler for TerrainServer {
 }
 
 impl TerrainServer {
-    pub fn new(engine: Traverze, base_dir: PathBuf, config: &Config, indexed_count: usize) -> Self {
+    pub fn new(
+        engine: Traverze,
+        indexed_paths: IndexedPaths,
+        config: &Config,
+        indexed_count: usize,
+    ) -> Self {
         let mut router = Self::tool_router();
 
         if let Some(desc) = &config.search_description {
@@ -177,7 +236,7 @@ impl TerrainServer {
 
         Self {
             engine,
-            base_dir,
+            indexed_paths,
             tool_router: router,
             instructions,
             indexed_count,

--- a/src/main.rs
+++ b/src/main.rs
@@ -9,7 +9,7 @@ use clap::Parser;
 use notify::event::{CreateKind, RemoveKind, RenameMode};
 use notify::{EventKind, RecommendedWatcher, RecursiveMode, Watcher};
 use rmcp::{ServiceExt, transport::stdio};
-use terrain::{Config, TerrainServer, build_engine, resolve_dir};
+use terrain::{Config, IndexedPaths, TerrainServer, build_engine, resolve_dir};
 use traverze::Traverze;
 
 /// terrain MCP server – Markdown full-text search
@@ -38,17 +38,20 @@ async fn main() -> Result<()> {
     let (engine, indexed) =
         build_engine(&index_dir, &markdown_files).context("failed to build search engine")?;
 
+    let indexed_paths = IndexedPaths::new();
+    indexed_paths.extend(markdown_files);
+
     eprintln!(
         "indexed {} markdown files from {}",
         indexed,
         target_dir.display()
     );
 
-    let _watcher = start_watcher(engine.clone(), target_dir.clone())
+    let _watcher = start_watcher(engine.clone(), indexed_paths.clone(), target_dir.clone())
         .context("failed to start file watcher")?;
     eprintln!("watching {} for changes", target_dir.display());
 
-    let server = TerrainServer::new(engine, target_dir, &config, indexed)
+    let server = TerrainServer::new(engine, indexed_paths, &config, indexed)
         .serve(stdio())
         .await?;
     server.waiting().await?;
@@ -73,7 +76,15 @@ fn collect_markdown_files(base_dir: &Path) -> Result<Vec<PathBuf>> {
             }
 
             if file_type.is_file() && is_markdown(&path) {
-                files.push(path);
+                // Canonicalize so paths line up with `fs::canonicalize` lookups
+                // performed by `read_file`, which on Windows yields `\\?\` paths.
+                match fs::canonicalize(&path) {
+                    Ok(canonical) => files.push(canonical),
+                    Err(e) => eprintln!(
+                        "warning: skipping {} (canonicalize failed: {e})",
+                        path.display()
+                    ),
+                }
             }
         }
     }
@@ -85,7 +96,11 @@ fn collect_markdown_files(base_dir: &Path) -> Result<Vec<PathBuf>> {
 ///
 /// Returns the [`RecommendedWatcher`] handle. The watcher stops when this
 /// handle is dropped, so keep it alive for the lifetime of the server.
-fn start_watcher(engine: Traverze, base_dir: PathBuf) -> Result<RecommendedWatcher> {
+fn start_watcher(
+    engine: Traverze,
+    indexed_paths: IndexedPaths,
+    base_dir: PathBuf,
+) -> Result<RecommendedWatcher> {
     let (tx, rx) = std::sync::mpsc::channel();
 
     let mut watcher = RecommendedWatcher::new(
@@ -122,14 +137,19 @@ fn start_watcher(engine: Traverze, base_dir: PathBuf) -> Result<RecommendedWatch
                     }
                 }
 
+                // Adds: canonicalize so the stored form matches read_file lookups.
                 let to_index: Vec<PathBuf> = pending
                     .iter()
                     .filter(|(_, kind)| {
                         matches!(kind, EventKind::Create(_) | EventKind::Modify(_))
                     })
-                    .map(|(path, _)| path.clone())
+                    .filter_map(|(path, _)| fs::canonicalize(path).ok())
                     .collect();
 
+                // Removes: file is already gone, so canonicalize will fail.
+                // Use the literal path; IndexedPaths::remove may miss the
+                // canonical form but that only leaves a stale entry — read_file
+                // would still fail at the I/O step.
                 let to_remove: Vec<PathBuf> = pending
                     .iter()
                     .filter(|(_, kind)| matches!(kind, EventKind::Remove(_)))
@@ -139,6 +159,9 @@ fn start_watcher(engine: Traverze, base_dir: PathBuf) -> Result<RecommendedWatch
                 pending.clear();
 
                 if !to_remove.is_empty() {
+                    for path in &to_remove {
+                        indexed_paths.remove(path);
+                    }
                     match engine.remove_files(&to_remove) {
                         Ok(n) => eprintln!("watcher: removed {} file(s) from index", n),
                         Err(e) => eprintln!("watcher: remove error: {e}"),
@@ -148,7 +171,10 @@ fn start_watcher(engine: Traverze, base_dir: PathBuf) -> Result<RecommendedWatch
                 if !to_index.is_empty() {
                     let _ = engine.remove_files(&to_index);
                     match engine.index_files(&to_index) {
-                        Ok(n) => eprintln!("watcher: re-indexed {} file(s)", n),
+                        Ok(n) => {
+                            indexed_paths.extend(to_index.iter().cloned());
+                            eprintln!("watcher: re-indexed {} file(s)", n);
+                        }
                         Err(e) => eprintln!("watcher: re-index error: {e}"),
                     }
                 }


### PR DESCRIPTION
# Restrict read_file access to indexed paths

## Summary

Replace `read_file`'s "path must live under `base_dir`" access check with a lookup against the set of paths currently registered in the index. Registration is now the permission grant: a path is readable via MCP iff it has been indexed.

## Motivation

Continuing the library/CLI decoupling started in the previous PR. The library no longer carries the notion of a single rooted base directory — embedding apps can register arbitrary files (potentially from multiple roots) and `read_file` will authorize them naturally without any extra configuration. This unblocks future use of terrain as a pure embedding primitive.

## Changes

### `src/lib.rs`
- Add `IndexedPaths` — a `Clone + Default` shared set wrapping `Arc<RwLock<HashSet<PathBuf>>>` with `insert` / `extend` / `remove` / `contains` / `len` / `is_empty`
- Replace `TerrainServer.base_dir` with `indexed_paths: IndexedPaths`
- `read_file` now denies with `"path is not in the index"` when the canonicalized input is missing from the set
- Drop the `base_dir` reference from the `on_initialized` log line
- `TerrainServer::new` signature: `(engine, indexed_paths, config, indexed_count)`

### `src/main.rs`
- `collect_markdown_files` canonicalizes each entry so initial-scan paths line up with `read_file`'s `fs::canonicalize` lookup (notably the Windows `\\?\` prefix)
- Construct `IndexedPaths`, seed it with the initial scan, and share it with both `TerrainServer` and the watcher
- Watcher add/modify events: canonicalize and `insert` into `IndexedPaths`
- Watcher remove events: call `remove` with the literal path; canonicalize fails post-deletion, but a stale entry is harmless because `read_file` still fails at the I/O step

## Notes

- Behaviorally equivalent for the existing CLI flow — files under `--dir` are scanned, indexed, and remain readable
- Stricter for embedders: a registered path is readable; an arbitrary path on disk is not
- Two pre-existing clippy warnings (`while_let_loop`, `clone_on_copy`) carried over from prior PRs are untouched to keep the diff focused
- Next step: simplify `TerrainServer::new` (drop `indexed_count`, move startup log to the CLI) and update README/CHANGELOG

---

## 概要

`read_file` のアクセス制御を「`base_dir` 配下に存在するか」から「インデックスに登録されているか」に置き換え。登録が認可行為そのものになり、インデックスに入っているパスのみが MCP 経由で読み取り可能。

## 背景

前 PR で始めたライブラリ / CLI の分離を継続。ライブラリが「単一のルートディレクトリ」概念を持たなくなることで、組み込み側のアプリは複数ルートにまたがる任意のファイルを登録でき、`read_file` の認可は自然に成立する。terrain を純粋な組み込みプリミティブとして使うための下地。

## 変更内容

### `src/lib.rs`
- `IndexedPaths` 型を追加。`Arc<RwLock<HashSet<PathBuf>>>` の薄いラッパで `insert` / `extend` / `remove` / `contains` / `len` / `is_empty` を提供（`Clone + Default`）
- `TerrainServer.base_dir` を削除し `indexed_paths: IndexedPaths` を保持
- `read_file` は canonicalize 後のパスが集合に無ければ `"path is not in the index"` で拒否
- `on_initialized` のログから `base_dir` 表示を削除
- `TerrainServer::new` のシグネチャ: `(engine, indexed_paths, config, indexed_count)`

### `src/main.rs`
- `collect_markdown_files` で各パスを `fs::canonicalize`。`read_file` 側の canonicalize と一致させるため（Windows の `\\?\` プレフィックス対策）
- `IndexedPaths` を生成し初回スキャン結果を投入、`TerrainServer` と watcher で共有
- watcher の create/modify: canonicalize して `insert`
- watcher の remove: 削除済みファイルは canonicalize 不可のため literal path で `remove`。集合に古いエントリが残っても `read_file` は I/O 段で失敗するため安全

## 備考

- 既存 CLI のフローには実質的な振る舞い変更なし（`--dir` 配下のファイルは従来通り読める）
- 組み込み側にはより厳格: 登録済みパスのみ読める
- 既存の clippy 警告 2 件（`while_let_loop`, `clone_on_copy`）は本 PR のスコープ外のため未対応
- 次ステップ: `TerrainServer::new` の簡素化（`indexed_count` 削除、起動ログを CLI へ移譲）と README / CHANGELOG 更新
