### PR TITLE
prepare for v0.2.0 release

### DIFF
--- a/CHANGELOG.ja.md
+++ b/CHANGELOG.ja.md
@@ -7,6 +7,8 @@
 
 ## [Unreleased]
 
+## [0.2.0] - 2026-06-20
+
 ### Added
 
 - ディレクトリの変更を監視してインデックスを自動更新するファイルウォッチャーを追加
@@ -38,5 +40,6 @@
 - `clap` 依存をオプショナルにする `cli` フィーチャーフラグ
 - Apache 2.0 および MIT デュアルライセンス
 
-[unreleased]: https://github.com/kyow/terrain/compare/v0.1.0...HEAD
+[unreleased]: https://github.com/kyow/terrain/compare/v0.2.0...HEAD
+[0.2.0]: https://github.com/kyow/terrain/compare/v0.1.0...v0.2.0
 [0.1.0]: https://github.com/kyow/terrain/releases/tag/v0.1.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.0] - 2026-06-20
+
 ### Added
 
 - File watcher to monitor directory changes and automatically update the index
@@ -38,5 +40,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Optional `cli` feature flag for `clap` dependency
 - Apache 2.0 and MIT dual license
 
-[unreleased]: https://github.com/kyow/terrain/compare/v0.1.0...HEAD
+[unreleased]: https://github.com/kyow/terrain/compare/v0.2.0...HEAD
+[0.2.0]: https://github.com/kyow/terrain/compare/v0.1.0...v0.2.0
 [0.1.0]: https://github.com/kyow/terrain/releases/tag/v0.1.0

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2767,7 +2767,7 @@ dependencies = [
 
 [[package]]
 name = "terrain"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "terrain"
-version = "0.1.0"
+version = "0.2.0"
 edition = "2024"
 rust-version = "1.85"
 description = "A lightweight, configurable, local-first full-text search engine for Markdown knowledge bases with Japanese text support"

--- a/README.ja.md
+++ b/README.ja.md
@@ -32,7 +32,7 @@ cargo install terrain
 
 ```toml
 [dependencies]
-terrain = { version = "0.1.0", default-features = false }
+terrain = { version = "0.2.0", default-features = false }
 ```
 
 デフォルトフィーチャーを無効にすると、CLI が使用する `clap` と `notify` への依存が外れ、組み込みに適した軽量なライブラリになります。

--- a/README.ja.md
+++ b/README.ja.md
@@ -1,0 +1,144 @@
+# terrain
+
+[English](README.md) | 日本語
+
+`terrain` は、Markdown のナレッジベース向けの軽量・設定可能・ローカルファーストな全文検索エンジンです。日本語テキストにも標準で対応しています。
+
+コマンドラインの MCP (Model Context Protocol) サーバーとして動作し、指定したディレクトリ内の `.md` ファイルをインデックス化して、検索・取得用のツールを公開します。
+
+## 特徴
+
+- **全文検索:** `tantivy` を基盤とする `traverze` 検索エンジンを利用。
+- **日本語対応:** IPADIC 辞書を用いた `lindera` により、日本語テキストを高精度に形態素解析・トークン化。
+- **MCP サーバー:** 標準入出力上にシンプルで機械可読なツールインターフェースを公開。
+- **自動インデックス:** 対象ディレクトリを監視し、ファイルの追加・変更・削除・リネームに応じてインデックスを自動更新（再起動は不要）。イベントはデバウンスされ、バッチ処理によって効率的に反映されます。
+- **安全性:** `read_file` はインデックスに登録済みのパスのみを返します。すなわち、インデックスへの登録がアクセス許可そのものになります。
+- **設定可能:** TOML 設定ファイルでツールの説明文をカスタマイズし、AI モデルの挙動を調整可能。
+- **クロスプラットフォーム:** Rust 製で、Windows・macOS・Linux で動作。
+
+## インストール
+
+[Rust](https://www.rust-lang.org/tools/install) がインストールされている必要があります。
+
+### CLI ツールとして
+
+```bash
+cargo install terrain
+```
+
+### ライブラリとして
+
+`Cargo.toml` に以下を追加します。
+
+```toml
+[dependencies]
+terrain = { version = "0.1.0", default-features = false }
+```
+
+デフォルトフィーチャーを無効にすると、CLI が使用する `clap` と `notify` への依存が外れ、組み込みに適した軽量なライブラリになります。
+
+ライブラリは以下の公開 API を提供します。
+
+- `Config` — TOML 設定ファイルの読み込みとパース。
+- `TerrainServer` — `rmcp` のトランスポートに組み込める MCP サーバーハンドラ。`TerrainServer::new(engine, indexed_paths, &config)` で構築します。
+- `IndexedPaths` — 現在インデックスに登録されているパスを保持する、クローン可能で共有可能な集合。`read_file` はこの集合を参照して読み取りを認可するため、組み込みアプリ側はパスを登録することでアクセスを制御します。
+- `resolve_dir` / `build_engine` — ディレクトリ解決と検索エンジン初期化のためのユーティリティ関数。
+
+ライブラリ自体はディレクトリの走査やファイルシステムの監視を行いません。どのファイルをいつ登録・再インデックスするかは組み込みアプリが決定します。`.md` ファイルのディレクトリを走査し、[`notify`](https://crates.io/crates/notify) でインデックスを同期し続ける統合例については [src/main.rs](src/main.rs) を参照してください。
+
+## MCP クライアントの設定
+
+Claude Desktop などの MCP 対応クライアントで `terrain` を使うには、クライアントの設定ファイル（例: `claude_desktop_config.json`）に以下を追加します。
+
+```json
+{
+  "mcpServers": {
+    "terrain": {
+      "command": "terrain",
+      "args": ["--dir", "/path/to/your/notes"]
+    }
+  }
+}
+```
+
+`cargo install` を使わずにソースからビルドした場合は、代わりに実行ファイルへのフルパス（例: `"/path/to/terrain"`）を指定してください。
+
+## 使い方
+
+1.  **サーバーの起動:**
+    Markdown ファイルを含むディレクトリを指定して、ターミナルからプログラムを実行します。
+
+    ```bash
+    terrain --dir /path/to/your/notes
+    ```
+
+2.  **インデックス化:**
+    サーバーはまず、指定ディレクトリ内のすべての Markdown ファイルをインデックス化します。何件のファイルがインデックスされたかを示すメッセージが表示されます。
+
+    ```
+    indexed 1234 markdown files from /path/to/your/notes
+    ```
+
+3.  **変更の監視:**
+    初回インデックス後、サーバーはディレクトリを監視し、インデックスを自動的に同期し続けます。Markdown ファイルの追加・編集・削除・リネーム時に再起動する必要はありません。ファイルシステムのイベントはデバウンスされてバッチ処理され、インデックス更新時には以下のようなログが表示されます。
+
+    ```
+    watching /path/to/your/notes for changes
+    watcher: re-indexed 1 file(s)
+    watcher: removed 1 file(s) from index
+    ```
+
+4.  **MCP 経由での操作:**
+    インデックス化が完了すると、サーバーは `stdin` で MCP の JSON リクエストを待ち受け、`stdout` にレスポンスを返します。このインターフェースは任意の MCP 対応クライアントやコントローラから利用できます。
+
+## 設定
+
+MCP では、ツールの説明文が「AI モデルがいつ・どのようにそのツールを使うか」の判断に直接影響します。TOML 設定ファイルを指定することで、これらの説明文をユースケースに合わせてカスタマイズできます。
+
+```bash
+terrain --dir /path/to/your/notes --config terrain.config.toml
+```
+
+利用可能なすべてのオプションについては [terrain.config.example.toml](terrain.config.example.toml) を参照してください。
+
+## MCP ツール
+
+サーバーは以下のツールを提供します。
+
+### `search`
+
+インデックス済みの Markdown ファイルを検索し、該当するファイルパス・スコア・スニペットを返します。
+
+- **説明:** 日本語テキストに高度に最適化されています。ユーザーの質問に答えるための関連コンテキストを見つけるために使用します。該当する絶対ファイルパス、関連度スコア、周辺テキストのスニペットの一覧を返します。
+- **パラメータ:**
+    - `query` (string, 必須): 検索クエリ。スペース区切りで複数のキーワードを指定できます。
+    - `limit` (integer, 任意): 返す検索結果の最大件数（デフォルト: 20）。
+- **戻り値の例:**
+    ```json
+    [
+      {
+        "path": "/path/to/your/notes/example.md",
+        "score": 18.72,
+        "snippet": "This is a snippet of text surrounding the matched keyword."
+      }
+    ]
+    ```
+
+### `read_file`
+
+指定した Markdown ファイルの全内容を読み取ります。
+
+- **説明:** `search` ツールで有望なスニペットを見つけ、より詳細なコンテキストが必要な場合に使用します。検索結果から取得した正確な絶対ファイルパスを指定してください。
+- **パラメータ:**
+    - `path` (string, 必須): 読み取る Markdown ファイルの絶対パス。`search` ツールが返した正確なパスを使用する必要があります。
+- **戻り値の例:**
+    指定した Markdown ファイルの生の全内容。
+
+## ライセンス
+
+以下のいずれかのライセンスで提供されます。
+
+- [Apache License, Version 2.0](LICENSE-APACHE)
+- [MIT License](LICENSE-MIT)
+
+どちらを選択しても構いません。

--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ It runs as a command-line MCP (Model Context Protocol) server, indexing a specif
 - **Full-Text Search:** Powered by the `traverze` search engine, built on `tantivy`.
 - **Japanese Support:** Utilizes `lindera` with an IPADIC dictionary for accurate morphological analysis and tokenization of Japanese text.
 - **MCP Server:** Exposes a simple, machine-readable tool interface over standard I/O.
+- **Auto-Indexing:** Watches the target directory and updates the index automatically when files are added, modified, removed, or renamed — no restart required. Events are debounced and processed in batches for efficiency.
 - **Secure:** `read_file` only serves paths that have been registered in the index, so registration is the permission grant.
 - **Configurable:** Customize tool descriptions via a TOML configuration file to tailor AI model behavior.
 - **Cross-Platform:** Built with Rust, runs on Windows, macOS, and Linux.
@@ -76,7 +77,16 @@ If you built from source without `cargo install`, use the full path to the execu
     indexed 1234 markdown files from /path/to/your/notes
     ```
 
-3.  **Interact via MCP:**
+3.  **Watching for changes:**
+    After the initial index, the server watches the directory and keeps the index in sync automatically — there is no need to restart when you add, edit, remove, or rename Markdown files. File-system events are debounced and processed in batches, and you will see log lines as the index is updated.
+
+    ```
+    watching /path/to/your/notes for changes
+    watcher: re-indexed 1 file(s)
+    watcher: removed 1 file(s) from index
+    ```
+
+4.  **Interact via MCP:**
     Once indexed, the server listens on `stdin` for MCP JSON requests and sends responses to `stdout`. You can use this interface with any MCP-compatible client or controller.
 
 ## Configuration

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ Add the following to your `Cargo.toml`:
 
 ```toml
 [dependencies]
-terrain = { version = "0.1.0", default-features = false }
+terrain = { version = "0.2.0", default-features = false }
 ```
 
 Disabling default features drops the `clap` and `notify` dependencies that the CLI uses, leaving a lean library suitable for embedding.

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # terrain
 
+English | [日本語](README.ja.md)
+
 `terrain` is a lightweight, configurable, local-first full-text search engine for your Markdown knowledge base, with built-in support for Japanese text.
 
 It runs as a command-line MCP (Model Context Protocol) server, indexing a specified directory of `.md` files and exposing search and retrieval tools.


### PR DESCRIPTION
# Prepare v0.2.0 release

## Summary

- Cut the `0.2.0` release: bump the crate version and finalize the changelog and docs.
- Move the `Unreleased` changelog entries into a dated `[0.2.0]` section (EN/JA) and fix the compare links.
- Document the auto-indexing (file watcher) behavior in the README and add a Japanese README translation.

## Motivation

The library/CLI split and the file-watcher work have already landed on `main`. This PR finalizes the documentation and version metadata so `0.2.0` can be tagged and published to crates.io. Since `0.2.0` includes breaking public-API changes (the `TerrainServer::new` signature change and removal of `collect_markdown_files` / `start_watcher`), a minor version bump is the correct step under 0.x SemVer.

## Changes

### Version
- Bump `Cargo.toml` (and `Cargo.lock`) to `0.2.0`.

### Changelog (`CHANGELOG.md`, `CHANGELOG.ja.md`)
- Promote `Unreleased` to `[0.2.0] - 2026-06-20`.
- Update compare links: `unreleased → v0.2.0...HEAD`, add `0.2.0 → v0.1.0...v0.2.0`.

### Docs (`README.md`, `README.ja.md`)
- Add an "Auto-Indexing" feature entry and a "Watching for changes" usage step with example log output.
- Add a Japanese README translation and cross-link it with the English version.
- Update the library dependency example to `version = "0.2.0"`.

## Notes

- No source-code changes; documentation and release metadata only.
- Tests are intentionally out of scope for this release and tracked separately.

---

# Prepare v0.2.0 release

## 概要

- `0.2.0` のリリース準備として、クレートのバージョンを更新し、CHANGELOG とドキュメントを確定。
- CHANGELOG の `Unreleased` を日付付きの `[0.2.0]` セクションへ移動（EN/JA）し、compare リンクを修正。
- 自動インデックス（ファイルウォッチャー）の挙動を README に記載し、日本語版 README を追加。

## 背景

ライブラリ/CLI 分割とファイルウォッチャーの実装は既に `main` にマージ済み。本 PR はドキュメントとバージョン情報を確定し、`0.2.0` をタグ付けして crates.io へ publish できる状態にするもの。`0.2.0` には破壊的な公開 API 変更（`TerrainServer::new` のシグネチャ変更、`collect_markdown_files` / `start_watcher` の削除）が含まれるため、0.x SemVer ではマイナーバージョンの更新が妥当。

## 変更内容

### バージョン
- `Cargo.toml`（および `Cargo.lock`）を `0.2.0` に更新。

### CHANGELOG（`CHANGELOG.md`, `CHANGELOG.ja.md`）
- `Unreleased` を `[0.2.0] - 2026-06-20` に昇格。
- compare リンクを更新: `unreleased → v0.2.0...HEAD`、`0.2.0 → v0.1.0...v0.2.0` を追加。

### ドキュメント（`README.md`, `README.ja.md`）
- 特徴に「自動インデックス」、使い方に「変更の監視」ステップ（ログ出力例つき）を追加。
- 日本語版 README を追加し、英語版と相互リンク。
- ライブラリ依存の記載例を `version = "0.2.0"` に更新。

## 備考

- ソースコードの変更はなく、ドキュメントとリリース用メタデータのみ。
- テストは本リリースのスコープ外とし、別途対応予定。
